### PR TITLE
Ignore all lines starting with dash

### DIFF
--- a/defrost/pipfreeze.py
+++ b/defrost/pipfreeze.py
@@ -11,7 +11,7 @@ def _parse_pip_freeze(pip_freeze_output):
     pip_freeze_output = io.StringIO(pip_freeze_output)
 
     for req in pip_freeze_output.readlines():
-        if req.startswith(('-e ', '-f ', '#')):
+        if req.startswith(('-', '#')):
             continue
         yield Package(req)
 


### PR DESCRIPTION
This fixes the problem that defrost chokes on a requirements file that has a `-i` or `--index-url` line.

Cc: @aconrad, @sudarkoff 