### PR TITLE
Ignore blank lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.3.2
+=====
+
+* gracefully handle blank lines and lines starting with dash
+  (https://github.com/SurveyMonkey/defrost/pull/14)
+
 0.3.1
 =====
 

--- a/defrost/pipfreeze.py
+++ b/defrost/pipfreeze.py
@@ -11,7 +11,8 @@ def _parse_pip_freeze(pip_freeze_output):
     pip_freeze_output = io.StringIO(pip_freeze_output)
 
     for req in pip_freeze_output.readlines():
-        if req.startswith(('-e ', '-f ', '#')):
+        req = req.strip()
+        if not req or req.startswith(('-', '#')):
             continue
         yield Package(req)
 


### PR DESCRIPTION
Ignore blank lines

Previously, defrost was choking on blank lines with:

    ValueError: ('No requirements found', u'\n')

Note: This PR contains https://github.com/SurveyMonkey/defrost/pull/13 in it, as I'm assuming that will probably be merged and this will prevent merge conflicts.