### PR TITLE
harden tests when for Requirement.specifiers

### DIFF
--- a/tests/test_requirement.py
+++ b/tests/test_requirement.py
@@ -12,7 +12,7 @@ def test_requirement(req, req_name, req_specs, req_id, req_repr, req_str):
     req = Requirement(req)
     assert req.id == req_id
     assert req.name == req_name
-    assert req.specifiers == req_specs
+    assert sorted(req.specifiers) == sorted(req_specs)
     assert repr(req) == req_repr
     assert str(req) == req_str
 


### PR DESCRIPTION
The `Requirement.specifiers` list is generated from a set causing the ordering of the items to be unpredictable. Here was the failing test:

```
=================================== FAILURES ===================================
 test_requirement[foo>=1.2,<2.0-foo-req_specs1-foo-Requirement(foo<2.0,>=1.2)-foo<2.0,>=1.2]

req = Requirement(foo<2.0,>=1.2), req_name = 'foo'
req_specs = [('>=', '1.2'), ('<', '2.0')], req_id = 'foo'
req_repr = 'Requirement(foo<2.0,>=1.2)', req_str = 'foo<2.0,>=1.2'

    @pytest.mark.parametrize("req, req_name, req_specs, req_id, req_repr, req_str", [
        ('foobar==1.2', 'foobar', [('==', '1.2')], 'foobar', 'Requirement(foobar==1.2)', 'foobar==1.2'),
        ('foo>=1.2,<2.0', 'foo', [('>=', '1.2'), ('<', '2.0')], 'foo', 'Requirement(foo<2.0,>=1.2)', 'foo<2.0,>=1.2'),
    ])
    def test_requirement(req, req_name, req_specs, req_id, req_repr, req_str):
        from defrost import Requirement
        req = Requirement(req)
        assert req.id == req_id
        assert req.name == req_name
>       assert req.specifiers == req_specs
E       assert [('<', '2.0'), ('>=', '1.2')] == [('>=', '1.2'), ('<', '2.0')]
E         At index 0 diff: ('<', '2.0') != ('>=', '1.2')
E         Full diff:
E         - [('<', '2.0'), ('>=', '1.2')]
E         + [('>=', '1.2'), ('<', '2.0')]

tests/test_requirement.py:15: AssertionError
```